### PR TITLE
Remove encryption workflow and update deployment name

### DIFF
--- a/.github/workflows/deploy-to-shop.yml
+++ b/.github/workflows/deploy-to-shop.yml
@@ -1,4 +1,4 @@
-name: Encode with IonCube
+name: Deploy to Shop
 
 on:
   workflow_run:
@@ -19,5 +19,5 @@ jobs:
           curl -X POST \
           -H "Content-Type: application/json" \
           -H "Authorization: ${{ secrets.RD_MOODLE_PLUGINS_WEBHOOK_TOKEN }}" \
-          -d '{"repository":"${{ github.repository }}", "branch":"${{ github.ref_name }}"}' \
+          -d '{"repository":"${{ github.repository }}", "branch":"${{ github.ref_name }}", "encrypt_required": "false"}' \
           ${{ secrets.RD_MOODLE_PLUGINS_WEBHOOK_URL }}


### PR DESCRIPTION
Eliminate the encryption and add deploy to shop with the webhook payload to indicate that encryption is not required.