### PR TITLE
fix(local_coursedynamicrules): clean up legacy CDR tables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+## 1.6.3
+
+**Released on:** 2026-04-29
+
+**Compatibility note:** This version is compatible with **Moodle 4.5**.
+
+## Fixed
+- **Database schema check reports legacy CDR tables**
+  Added an upgrade cleanup step that removes obsolete `cdr_rule`, `cdr_condition`, and `cdr_action` tables when they remain in existing sites.
+
+## Added
+- **Automated coverage for legacy table cleanup**
+  Added PHPUnit coverage to validate that the upgrade helper drops legacy CDR tables safely.
+
 ## 1.6.2
 
 **Released on:** 2026-04-24

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -182,6 +182,11 @@ function xmldb_local_coursedynamicrules_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2026042300, 'local', 'coursedynamicrules');
     }
 
+    if ($oldversion < 2026042401) {
+        local_coursedynamicrules_upgrade_cleanup_legacy_tables();
+        upgrade_plugin_savepoint(true, 2026042401, 'local', 'coursedynamicrules');
+    }
+
     return true;
 }
 
@@ -242,5 +247,24 @@ function local_coursedynamicrules_upgrade_migrate_sendnotification_roles(): void
         unset($params['roleids']);
 
         $DB->set_field('local_coursedynamicrules_action', 'params', json_encode($params), ['id' => $action->id]);
+    }
+}
+
+/**
+ * Drop legacy cdr_* tables that are no longer used by this plugin.
+ *
+ * @return void
+ */
+function local_coursedynamicrules_upgrade_cleanup_legacy_tables(): void {
+    global $DB;
+
+    $dbman = $DB->get_manager();
+    $legacytables = ['cdr_action', 'cdr_condition', 'cdr_rule'];
+
+    foreach ($legacytables as $tablename) {
+        $table = new xmldb_table($tablename);
+        if ($dbman->table_exists($table)) {
+            $dbman->drop_table($table);
+        }
     }
 }

--- a/tests/upgrade_legacy_tables_cleanup_test.php
+++ b/tests/upgrade_legacy_tables_cleanup_test.php
@@ -1,0 +1,57 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_coursedynamicrules;
+
+/**
+ * Tests cleanup of legacy CDR tables during plugin upgrade.
+ *
+ * @package    local_coursedynamicrules
+ * @covers     ::local_coursedynamicrules_upgrade_cleanup_legacy_tables
+ * @copyright  2026 Industria Elearning <info@industriaelearning.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class upgrade_legacy_tables_cleanup_test extends \advanced_testcase {
+    /**
+     * Test legacy cdr_* tables are dropped when they still exist.
+     */
+    public function test_upgrade_cleanup_drops_legacy_tables(): void {
+        global $DB, $CFG;
+
+        $this->resetAfterTest(true);
+        require_once($CFG->dirroot . '/local/coursedynamicrules/db/upgrade.php');
+
+        $dbman = $DB->get_manager();
+
+        $legacytables = ['cdr_rule', 'cdr_condition', 'cdr_action'];
+        foreach ($legacytables as $tablename) {
+            $table = new \xmldb_table($tablename);
+            $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+            $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+
+            if (!$dbman->table_exists($table)) {
+                $dbman->create_table($table);
+            }
+        }
+
+        \local_coursedynamicrules_upgrade_cleanup_legacy_tables();
+
+        foreach ($legacytables as $tablename) {
+            $table = new \xmldb_table($tablename);
+            $this->assertFalse($dbman->table_exists($table));
+        }
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_coursedynamicrules';
-$plugin->release = '1.6.2';
-$plugin->version = 2026042400;
+$plugin->release = '1.6.3';
+$plugin->version = 2026042900;
 $plugin->requires = 2024100700; // Moodle 4.5.
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [405, 405];


### PR DESCRIPTION
### Context
Moodle Database schema check reports legacy tables (`cdr_action`, `cdr_condition`, `cdr_rule`) as unexpected in existing sites.

### Description
- Add an upgrade step that removes obsolete legacy `cdr_*` tables when they still exist
- Bump plugin release and version so the upgrade step runs in upgraded environments
- Add PHPUnit coverage for the legacy-table cleanup helper
- Update `CHANGES.md` for release `1.6.3`

### Steps to review
1. Upgrade the plugin to this branch version (`2026042900`)
2. Open **Performance overview > Database schema check**
3. Confirm `cdr_action`, `cdr_condition`, and `cdr_rule` are no longer reported as unexpected

### Verification
Lint and plugin validation checks pass for this plugin scope. Existing environment-wide CI issues are unrelated to this change.

### License
By submitting this pull request, I confirm that my contribution is made under the terms of the project license.