### PR TITLE
fix(condition): handle null completionstate in no_complete_activity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+## 1.6.3
+
+**Released on:** 2026-05-08
+
+**Compatibility note:** This version is compatible with **Moodle 4.5**.
+
+## Fixed
+- **TypeError in no_complete_activity condition when completion tracking is disabled**
+  Fixed a fatal `TypeError` thrown by the scheduled task when a user had visited an activity that has completion tracking disabled (`COMPLETION_TRACKING_NONE`). The Moodle `completion_info::get_data()` RIGHT JOIN returns `completionstate = NULL` in that scenario; the condition now guards against a null value and returns `false` early instead of crashing.
+
+---
+
 ## 1.6.2
 
 **Released on:** 2026-04-24
@@ -15,8 +27,6 @@
   Fixed cases where notification placeholders could be rendered with incorrect user data when different role combinations were selected.
 - **No-course-access delivery semantics**
   Notifications are now sent only when the matched user belongs to primary recipient roles, while copy recipients receive an observation message.
-- **TypeError in no_complete_activity condition when completion tracking is disabled**
-  Fixed a fatal `TypeError` thrown by the scheduled task when a user had visited an activity that has completion tracking disabled (`COMPLETION_TRACKING_NONE`). The Moodle `completion_info::get_data()` RIGHT JOIN returns `completionstate = NULL` in that scenario; the condition now guards against a null value and returns `false` early instead of crashing.
 
 ## Added
 - **Upgrade migration for legacy role params**

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
   Fixed cases where notification placeholders could be rendered with incorrect user data when different role combinations were selected.
 - **No-course-access delivery semantics**
   Notifications are now sent only when the matched user belongs to primary recipient roles, while copy recipients receive an observation message.
+- **TypeError in no_complete_activity condition when completion tracking is disabled**
+  Fixed a fatal `TypeError` thrown by the scheduled task when a user had visited an activity that has completion tracking disabled (`COMPLETION_TRACKING_NONE`). The Moodle `completion_info::get_data()` RIGHT JOIN returns `completionstate = NULL` in that scenario; the condition now guards against a null value and returns `false` early instead of crashing.
 
 ## Added
 - **Upgrade migration for legacy role params**

--- a/classes/condition/no_complete_activity/no_complete_activity_condition.php
+++ b/classes/condition/no_complete_activity/no_complete_activity_condition.php
@@ -119,6 +119,13 @@ class no_complete_activity_condition extends condition {
             $userid
         );
 
+        // If completionstate is null the activity has no completion tracking enabled
+        // (e.g. the user visited the activity but no completion record exists). We
+        // cannot determine whether the activity was completed, so bail out early.
+        if (!isset($completiondata->completionstate)) {
+            return false;
+        }
+
         // Return false if the user has completed the activity module because is not necessary execute the actions of the rule.
         if ($this->is_completed_state($completiondata->completionstate)) {
             return false;

--- a/tests/condition/no_complete_activity_condition_test.php
+++ b/tests/condition/no_complete_activity_condition_test.php
@@ -1,0 +1,240 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_coursedynamicrules\condition;
+
+use local_coursedynamicrules\condition\no_complete_activity\no_complete_activity_condition;
+
+/**
+ * Tests for No Complete Activity condition.
+ *
+ * @package    local_coursedynamicrules
+ * @category   test
+ * @coversDefaultClass \local_coursedynamicrules\condition\no_complete_activity\no_complete_activity_condition
+ * @copyright  2026 Industria Elearning <info@industriaelearning.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class no_complete_activity_condition_test extends \advanced_testcase {
+    /** @var int Timestamp in the past (expected completion date already passed) */
+    private int $pastdate;
+
+    /** @var int Timestamp in the future (expected completion date not yet passed) */
+    private int $futuredate;
+
+    /**
+     * Test setup.
+     */
+    public function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+
+        $this->pastdate   = strtotime('-7 days');
+        $this->futuredate = strtotime('+7 days');
+    }
+
+    /**
+     * Build a condition record pointing at the given cm and expected completion date.
+     *
+     * @param int $cmid Course-module ID.
+     * @param int $expectedcompletiondate Unix timestamp.
+     * @return no_complete_activity_condition
+     */
+    private function create_condition(int $cmid, int $expectedcompletiondate): no_complete_activity_condition {
+        $record = (object) [
+            'ruleid'        => 1,
+            'conditiontype' => 'no_complete_activity',
+            'params'        => json_encode([
+                'cmid'                   => $cmid,
+                'expectedcompletiondate' => $expectedcompletiondate,
+            ]),
+        ];
+
+        return new no_complete_activity_condition($record);
+    }
+
+    /**
+     * When the expected completion date is in the future the condition must not
+     * fire regardless of the user's completion state.
+     *
+     * @covers ::evaluate
+     */
+    public function test_evaluate_returns_false_when_deadline_not_reached(): void {
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $user   = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        $assign = $this->getDataGenerator()->create_module(
+            'assign',
+            ['course' => $course->id, 'completion' => COMPLETION_TRACKING_AUTOMATIC]
+        );
+
+        $condition = $this->create_condition($assign->cmid, $this->futuredate);
+        $result = $condition->evaluate((object) ['courseid' => $course->id, 'userid' => $user->id]);
+
+        $this->assertFalse($result, 'Condition must not fire before the expected completion date.');
+    }
+
+    /**
+     * Regression test: activity has completion tracking disabled.
+     * get_data() returns completionstate = NULL via a RIGHT JOIN on
+     * course_modules_viewed when there is no course_modules_completion row.
+     * evaluate() must handle the null gracefully and return false (cannot
+     * determine incomplete status without tracking).
+     *
+     * @covers ::evaluate
+     */
+    public function test_evaluate_returns_false_when_completion_tracking_disabled(): void {
+        global $DB;
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $user   = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        // Create activity WITHOUT completion tracking (COMPLETION_TRACKING_NONE = 0).
+        $assign = $this->getDataGenerator()->create_module(
+            'assign',
+            ['course' => $course->id, 'completion' => COMPLETION_TRACKING_NONE]
+        );
+
+        // Simulate the user having visited the activity so a course_modules_viewed
+        // row exists — this triggers the RIGHT JOIN path that yields completionstate = NULL.
+        $DB->insert_record('course_modules_viewed', (object) [
+            'coursemoduleid' => $assign->cmid,
+            'userid'         => $user->id,
+            'timecreated'    => time(),
+        ]);
+
+        $condition = $this->create_condition($assign->cmid, $this->pastdate);
+        $result = $condition->evaluate((object) ['courseid' => $course->id, 'userid' => $user->id]);
+
+        $this->assertFalse(
+            $result,
+            'Condition must return false when completion tracking is disabled (completionstate is null).'
+        );
+    }
+
+    /**
+     * Activity is not completed and deadline has passed: condition fires.
+     *
+     * @covers ::evaluate
+     */
+    public function test_evaluate_returns_true_when_not_completed_and_deadline_passed(): void {
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $user   = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        $assign = $this->getDataGenerator()->create_module(
+            'assign',
+            ['course' => $course->id, 'completion' => COMPLETION_TRACKING_MANUAL]
+        );
+
+        // User has NOT marked the activity complete — no completion record.
+        $condition = $this->create_condition($assign->cmid, $this->pastdate);
+        $result = $condition->evaluate((object) ['courseid' => $course->id, 'userid' => $user->id]);
+
+        $this->assertTrue($result, 'Condition must fire when the activity is not completed and the deadline has passed.');
+    }
+
+    /**
+     * Activity is completed (COMPLETION_COMPLETE): condition must not fire.
+     *
+     * @covers ::evaluate
+     */
+    public function test_evaluate_returns_false_when_activity_is_completed(): void {
+        global $DB;
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $user   = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        $assign = $this->getDataGenerator()->create_module(
+            'assign',
+            ['course' => $course->id, 'completion' => COMPLETION_TRACKING_MANUAL]
+        );
+
+        // Mark the activity as completed.
+        $DB->insert_record('course_modules_completion', (object) [
+            'coursemoduleid' => $assign->cmid,
+            'userid'         => $user->id,
+            'completionstate' => COMPLETION_COMPLETE,
+            'timemodified'   => time(),
+        ]);
+
+        $condition = $this->create_condition($assign->cmid, $this->pastdate);
+        $result = $condition->evaluate((object) ['courseid' => $course->id, 'userid' => $user->id]);
+
+        $this->assertFalse($result, 'Condition must not fire when the activity is already completed.');
+    }
+
+    /**
+     * Activity is completed with pass grade (COMPLETION_COMPLETE_PASS): condition must not fire.
+     *
+     * @covers ::evaluate
+     */
+    public function test_evaluate_returns_false_when_activity_completed_with_pass(): void {
+        global $DB;
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $user   = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        $assign = $this->getDataGenerator()->create_module(
+            'assign',
+            ['course' => $course->id, 'completion' => COMPLETION_TRACKING_MANUAL]
+        );
+
+        // Mark the activity as completed with passing grade.
+        $DB->insert_record('course_modules_completion', (object) [
+            'coursemoduleid' => $assign->cmid,
+            'userid'         => $user->id,
+            'completionstate' => COMPLETION_COMPLETE_PASS,
+            'timemodified'   => time(),
+        ]);
+
+        $condition = $this->create_condition($assign->cmid, $this->pastdate);
+        $result = $condition->evaluate((object) ['courseid' => $course->id, 'userid' => $user->id]);
+
+        $this->assertFalse($result, 'Condition must not fire when the activity is completed with a pass grade.');
+    }
+
+    /**
+     * Activity module is being deleted: condition must not fire.
+     *
+     * @covers ::evaluate
+     */
+    public function test_evaluate_returns_false_when_cm_deletion_in_progress(): void {
+        global $DB;
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $user   = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        $assign = $this->getDataGenerator()->create_module(
+            'assign',
+            ['course' => $course->id, 'completion' => COMPLETION_TRACKING_MANUAL]
+        );
+
+        // Flag the course module as being deleted and flush the modinfo cache so
+        // get_fast_modinfo() picks up the updated field.
+        $DB->set_field('course_modules', 'deletioninprogress', 1, ['id' => $assign->cmid]);
+        rebuild_course_cache($course->id, true);
+
+        $condition = $this->create_condition($assign->cmid, $this->pastdate);
+        $result = $condition->evaluate((object) ['courseid' => $course->id, 'userid' => $user->id]);
+
+        $this->assertFalse($result, 'Condition must not fire when the course module is being deleted.');
+    }
+}

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_coursedynamicrules';
 $plugin->release = '1.6.2';
-$plugin->version = 2026042400;
+$plugin->version = 2026050800;
 $plugin->requires = 2024100700; // Moodle 4.5.
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [405, 405];

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_coursedynamicrules';
-$plugin->release = '1.6.2';
+$plugin->release = '1.6.3';
 $plugin->version = 2026050800;
 $plugin->requires = 2024100700; // Moodle 4.5.
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
### Context

Fixes a fatal `TypeError` that crashes the `no_complete_activity_task` scheduled task when a user has visited an activity that has completion tracking disabled (`COMPLETION_TRACKING_NONE`).

### Description

`completion_info::get_data()` uses a SQL UNION with a RIGHT JOIN between `course_modules_completion` and `course_modules_viewed`. When a user has a `course_modules_viewed` row but no `course_modules_completion` row (completion tracking disabled), the RIGHT JOIN yields `completionstate = NULL`. PHP 8 enforces strict type declarations and throws a `TypeError` when `null` is passed to `is_completed_state(int $completionstate)`.

**Fix**: added an `!isset($completiondata->completionstate)` guard in `evaluate()` immediately after `get_data()`. If `completionstate` is `null`, the method returns `false` early — the activity cannot be evaluated as incomplete without tracking enabled.

**Files changed:**
- `classes/condition/no_complete_activity/no_complete_activity_condition.php` — defensive null guard added
- `tests/condition/no_complete_activity_condition_test.php` — new test class (regression + 5 evaluate scenarios)
- `version.php` — release bumped to `1.6.3`, build number to `2026050800`
- `CHANGES.md` — `1.6.3` section added with fix entry; `1.6.2` left immutable

### Steps to review

1. Check out this branch and run the scheduled task against a course where an activity has completion tracking disabled and at least one student has visited it.
2. Confirm the task completes without `TypeError`.
3. Run the PHPUnit suite for the plugin and verify 6/6 tests pass in `no_complete_activity_condition_test`.

### Verification

All 6 PHPUnit tests in `no_complete_activity_condition_test` pass, including the regression test that directly reproduces the null completionstate scenario via a `course_modules_viewed` row without a matching `course_modules_completion` row. All preflight checks (phplint, phpcs, phpdoc, validate, savepoints, mustache, grunt) pass with no blocking failures.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the project license.